### PR TITLE
Fix post user override

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -37,7 +37,7 @@ class Post extends Model
     protected static function booted(): void
     {
         static::creating(function ($post) {
-            if (Auth::check()) {
+            if (Auth::check() && empty($post->user_id)) {
                 $post->user_id = Auth::id();
             }
         });


### PR DESCRIPTION
## Summary
- prevent overriding custom user_id when creating posts

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684105271ab08322be4127786edcaa32