### PR TITLE
[HPB-72] [Admin] admin 不應可以去編輯作者的資料

### DIFF
--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -101,7 +101,7 @@ class PostResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         $query = parent::getEloquentQuery();
-        if (auth()->check() && auth()->user()->role !== 'admin') {
+        if (auth()->check()) {
             $query->where('user_id', auth()->id());
         }
         return $query;


### PR DESCRIPTION
讓admin權限使用者無法編輯非自己的文章，詳細敘述放在[這裡](https://www.notion.so/jyu1999/Happy-Partner-Blog-Issue-Tracker-1fccba948f1180299165efbc16a18c85?p=20ecba948f118057be75f2551e022f49&pm=s)。

- 測試：
    1. admin使用者目前沒辦法看到非自己的寫的文章
        
       <img width="2048" height="1272" alt="image" src="https://github.com/user-attachments/assets/bee40db0-cc9f-474e-a1f7-e53ffd9b62ee" />
        
    2. 如果admin使用者透過網址想要access該篇文章，filament也會導向404
        
        <img width="2048" height="1273" alt="image" src="https://github.com/user-attachments/assets/45499f29-b7fc-4808-a15c-1c9a45f6254f" />