### PR TITLE
[HPB-86] [FE] 選擇 PrimeVue 整合策略，並配置到專案中

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "tailwind-merge": "^3.2.0",
                 "tailwindcss": "^4.1.1",
                 "tailwindcss-animate": "^1.0.7",
+                "tailwindcss-primeui": "^0.6.1",
                 "tw-animate-css": "^1.2.5",
                 "typescript": "^5.2.2",
                 "vite": "^6.2.0",
@@ -4668,6 +4669,15 @@
             "license": "MIT",
             "peerDependencies": {
                 "tailwindcss": ">=3.0.0 || insiders"
+            }
+        },
+        "node_modules/tailwindcss-primeui": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/tailwindcss-primeui/-/tailwindcss-primeui-0.6.1.tgz",
+            "integrity": "sha512-T69Rylcrmnt8zy9ik+qZvsLuRIrS9/k6rYJSIgZ1trnbEzGDDQSCIdmfyZknevqiHwpSJHSmQ9XT2C+S/hJY4A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "tailwindcss": ">=3.1.0"
             }
         },
         "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.1",
         "tailwindcss-animate": "^1.0.7",
+        "tailwindcss-primeui": "^0.6.1",
         "tw-animate-css": "^1.2.5",
         "typescript": "^5.2.2",
         "vite": "^6.2.0",

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,4 +1,5 @@
-@import 'tailwindcss';
+@import "tailwindcss";
+@import "tailwindcss-primeui";
 
 @import "tw-animate-css";
 @import "primeicons/primeicons.css";

--- a/resources/js/composables/usePrimeVue.ts
+++ b/resources/js/composables/usePrimeVue.ts
@@ -3,7 +3,12 @@ import PrimeVue from "primevue/config";
 
 export function initializePrimeVue(app: App) {
     app.use(PrimeVue, {
-        // TODO: 目前尚未確認是否使用 unstyled 模式，如果後續確認使用 unstyled 模式，應考慮將 `@primeuix/themes` 套件刪除
-        unstyled: true
+        unstyled: true,
+        pt: {
+            /**
+             * Defines the shared pass through properties per component type.
+             * @see https://primevue.org/passthrough
+             */
+        }
     });
 }


### PR DESCRIPTION
https://www.notion.so/jyu1999/FE-PrimeVue-228cba948f11804e91bed40b1e6d8f39?source=copy_link


此 PR 的核心目標是將 PrimeVue 與專案現有的 Tailwind CSS進行深度整合。
根據 Task 內的分析，選擇了 PrimeVue 的 Unstyled 模式，並採用官方推薦的 Tailwind CSS Preset (tailwindcss-primeui) 作為最終整合方案。

這個策略能帶來以下關鍵優勢：

* 避免樣式衝突：徹底移除 PrimeVue 的預設樣式，讓 Tailwind CSS 完全接管，從根本上杜絕了 CSS 權重和規則衝突的問題。
* 維持設計系統一致性：所有元件的樣式都將由 tailwind.config.js 中定義的 Design Token 和 Utility-First class 來驅動，確保了視覺風格的統一。
* 最大化開發效率：開發者可以使用熟悉的 Tailwind class 來客製化 PrimeVue 元件，無需學習另一套樣式系統。



本地需執行 `sail npm install` 和 `sail npm run dev`