### PR TITLE
[HPB-22] [BE] post.status 評估使用 enum 管理

### DIFF
--- a/app/Enums/PostStatus.php
+++ b/app/Enums/PostStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum PostStatus: string
+{
+    case Draft = 'draft';
+    case Published = 'published';
+}

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -49,7 +49,7 @@ class PostResource extends Resource
                         PostStatus::Published->value => 'Published',
                     ])
                     ->required()
-                    ->default(PostStatus::Draft)
+                    ->default(PostStatus::Draft->value)
                     ->reactive(),
             ]);
     }

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Enums\PostStatus;
 use App\Filament\Resources\PostResource\Pages;
 use App\Models\Post;
 use Filament\Forms\Components\MarkdownEditor;
@@ -44,8 +45,8 @@ class PostResource extends Resource
                     ->columnSpanFull(),
                 Select::make('status')
                     ->options([
-                        'draft' => 'Draft',
-                        'published' => 'Published',
+                        PostStatus::Draft->value => 'Draft',
+                        PostStatus::Published->value => 'Published',
                     ])
                     ->required()
                     ->default('draft')
@@ -70,8 +71,7 @@ class PostResource extends Resource
                     ])
                     ->searchable(),
             ])
-            ->filters([
-            ])
+            ->filters([])
             ->actions([
                 Tables\Actions\EditAction::make(),
                 Tables\Actions\DeleteAction::make(),

--- a/app/Filament/Resources/PostResource.php
+++ b/app/Filament/Resources/PostResource.php
@@ -49,7 +49,7 @@ class PostResource extends Resource
                         PostStatus::Published->value => 'Published',
                     ])
                     ->required()
-                    ->default('draft')
+                    ->default(PostStatus::Draft)
                     ->reactive(),
             ]);
     }
@@ -66,8 +66,8 @@ class PostResource extends Resource
                     ->sortable(),
                 Tables\Columns\BadgeColumn::make('status')
                     ->colors([
-                        'secondary' => 'draft',
-                        'success' => 'published',
+                        'secondary' => PostStatus::Draft->value,
+                        'success' => PostStatus::Published->value,
                     ])
                     ->searchable(),
             ])

--- a/app/Http/Controllers/Frontend/PostController.php
+++ b/app/Http/Controllers/Frontend/PostController.php
@@ -24,7 +24,7 @@ class PostController extends Controller
 
     public function show(Post $post): Response
     {
-        if ($post->status !== PostStatus::Published) {
+        if ($post->status !== PostStatus::Published->value) {
             abort(404);
         }
 

--- a/app/Http/Controllers/Frontend/PostController.php
+++ b/app/Http/Controllers/Frontend/PostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Frontend;
 
+use App\Enums\PostStatus;
 use App\Http\Controllers\Controller;
 use App\Models\Post;
 use Inertia\Inertia;
@@ -12,7 +13,7 @@ class PostController extends Controller
     public function index(): Response
     {
         $posts = Post::with('user')
-            ->where('status', 'published')
+            ->where('status', PostStatus::Published->value)
             ->orderByDesc('id')
             ->paginate(10);
 
@@ -23,7 +24,7 @@ class PostController extends Controller
 
     public function show(Post $post): Response
     {
-        if ($post->status !== 'published') {
+        if ($post->status !== PostStatus::Published) {
             abort(404);
         }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Enums\PostStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,9 +29,7 @@ class Post extends Model
      *
      * @var array<string, string>
      */
-    protected $casts = [
-        'status' => PostStatus::class,
-    ];
+    protected $casts = [];
 
     /**
      * The "booted" method of the model.

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\PostStatus;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -29,7 +30,9 @@ class Post extends Model
      *
      * @var array<string, string>
      */
-    protected $casts = [];
+    protected $casts = [
+        'status' => PostStatus::class,
+    ];
 
     /**
      * The "booted" method of the model.

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\PostStatus;
 use App\Models\Post;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -17,7 +18,7 @@ class PostFactory extends Factory
             'title' => $this->faker->sentence(),
             'slug' => $this->faker->slug(),
             'content' => $this->faker->paragraph(),
-            'status' => 'published',
+            'status' => PostStatus::Published,
         ];
     }
 }

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -18,7 +18,7 @@ class PostFactory extends Factory
             'title' => $this->faker->sentence(),
             'slug' => $this->faker->slug(),
             'content' => $this->faker->paragraph(),
-            'status' => PostStatus::Published,
+            'status' => PostStatus::Published->value,
         ];
     }
 }

--- a/database/migrations/2025_07_27_063526_alter_posts_status_column.php
+++ b/database/migrations/2025_07_27_063526_alter_posts_status_column.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Enums\PostStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('status')->default(PostStatus::Draft->value)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('status')->default('draft')->change();
+        });
+    }
+};


### PR DESCRIPTION
## Description
### 測試案例編號：TC001
測試名稱： PostStatus Enum 正確定義與使用
測試對象： App\Enums\PostStatus
初始條件： 系統已存在 PostStatus Enum，包含 draft 與 published
測試步驟：
1. 檢查 Enum 中是否包含 Draft, Published 兩個值

預期結果：
1. Enum 正確定義，語法無誤
2. 每個值的 value 與名稱皆正確可用

✅ 測試結果：通過

### 測試案例編號：TC002
測試名稱： PostFactory 可正確產生 Enum status 資料
測試對象： PostFactory
初始條件： 已修改 Factory 使用 Enum
測試步驟：
1. 執行 Post::factory()->create()
2. 檢查產生出來的資料，其 status 欄位為 PostStatus::Published
3. 確保資料存入資料庫為 'published' 字串

預期結果：
1. Factory 可正常使用 Enum 產生資料
2. 資料轉換為正確的字串值儲存至資料庫

✅ 測試結果：通過

### 測試案例編號：TC003
測試名稱： 前端 Resource 表單正確顯示 Enum 選項
測試對象： Resource 表單中 status 欄位
初始條件： 表單已設定 ->options() 並使用 Enum
測試步驟：
1. 開啟 Resource 的建立文章頁面
2. 檢查 status 欄位選項是否為：Draft、Published
3. 檢查預設值為 draft

預期結果：
1. 選項來自 Enum 的 value
2. 表單顯示與預設值皆符合設計

✅ 測試結果：通過

### 測試案例編號：TC004
測試名稱： PostResource 顯示欄位正確使用 Enum
測試對象： Resource 頁面
初始條件： 顯示使用 Badge 或 Select 取自 Enum 
測試步驟：
1. 開啟文章列表頁
2. 檢查每筆資料的 status 欄位為 Draft 或 Published

預期結果：
1. 顯示欄位有 Draft 或 Published

✅ 測試結果：通過

## Related Task
[[HPB-22][BE] post.status 評估使用 enum 管理](https://www.notion.so/jyu1999/BE-post-status-enum-1fccba948f1180f08f39f6f51462d3ab)