### PR TITLE
[HPB-77] [FE] 將文章一覽 Pagination 元件化

### DIFF
--- a/resources/js/components/IndexPagination.vue
+++ b/resources/js/components/IndexPagination.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="posts.data.length > 0 && posts.links.length > 3" class="mt-12">
+    <div v-if="posts.links.length > 3" class="mt-12">
         <nav class="flex items-center justify-between">
             <div class="flex-1 flex justify-between sm:hidden">
                 <Link v-if="posts.links[0].url" :href="posts.links[0].url || '#'"
@@ -39,17 +39,6 @@ import { Link } from '@inertiajs/vue3';
 
 const { posts } = defineProps<{
     posts: {
-        data: Array<{
-            id: number;
-            title: string;
-            slug: string;
-            content: string; // Full content, we'll need to truncate for preview
-            updated_at: string;
-            user: {
-                name: string;
-            };
-            // Add other fields from your Post model as needed
-        }>;
         links: Array<{
             url: string | null;
             label: string;

--- a/resources/js/components/IndexPagination.vue
+++ b/resources/js/components/IndexPagination.vue
@@ -5,13 +5,13 @@
                 <Link v-if="posts.links[0].url" :href="posts.links[0].url || '#'"
                     class="relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
                     preserve-scroll>
-                <div v-html="posts.links[0].label"></div>
+                <span v-html="posts.links[0].label"></span>
                 </Link>
                 <Link v-if="posts.links[posts.links.length - 1].url"
                     :href="posts.links[posts.links.length - 1].url || '#'"
                     class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
                     preserve-scroll>
-                <div v-html="posts.links[posts.links.length - 1].label"></div>
+                <span v-html="posts.links[posts.links.length - 1].label"></span>
                 </Link>
             </div>
             <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-center">
@@ -24,7 +24,7 @@
                                     'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700': !link.active && link.url,
                                     'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-500': !link.url
                                 }" :disabled="!link.url" preserve-scroll>
-                            <div v-html="link.label"></div>
+                            <span v-html="link.label"></span>
                             </Link>
                         </template>
                     </span>

--- a/resources/js/components/IndexPagination.vue
+++ b/resources/js/components/IndexPagination.vue
@@ -4,14 +4,14 @@
             <div class="flex-1 flex justify-between sm:hidden">
                 <Link v-if="posts.links[0].url" :href="posts.links[0].url || '#'"
                     class="relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    preserve-scroll>
-                <div v-html="posts.links[0].label"></div>
+                    preserve-scroll
+                    v-html="posts.links[0].label">
                 </Link>
                 <Link v-if="posts.links[posts.links.length - 1].url"
                     :href="posts.links[posts.links.length - 1].url || '#'"
                     class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    preserve-scroll>
-                <div v-html="posts.links[posts.links.length - 1].label"></div>
+                    preserve-scroll
+                    v-html="posts.links[posts.links.length - 1].label">
                 </Link>
             </div>
             <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-center">
@@ -23,8 +23,7 @@
                                     'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-indigo-900 dark:border-indigo-700 dark:text-indigo-300': link.active,
                                     'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700': !link.active && link.url,
                                     'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-500': !link.url
-                                }" :disabled="!link.url" preserve-scroll>
-                            <div v-html="link.label"></div>
+                                }" :disabled="!link.url" preserve-scroll v-html="link.label">
                             </Link>
                         </template>
                     </span>
@@ -44,7 +43,6 @@ const { posts } = defineProps<{
             label: string;
             active: boolean;
         }>;
-        // other pagination properties like current_page, last_page, etc., if needed directly
     };
 }>();
 </script>

--- a/resources/js/components/IndexPagination.vue
+++ b/resources/js/components/IndexPagination.vue
@@ -1,0 +1,61 @@
+<template>
+    <div v-if="posts.data.length > 0 && posts.links.length > 3" class="mt-12">
+        <nav class="flex items-center justify-between">
+            <div class="flex-1 flex justify-between sm:hidden">
+                <Link v-if="posts.links[0].url" :href="posts.links[0].url || '#'"
+                    class="relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    preserve-scroll>
+                <div v-html="posts.links[0].label"></div>
+                </Link>
+                <Link v-if="posts.links[posts.links.length - 1].url"
+                    :href="posts.links[posts.links.length - 1].url || '#'"
+                    class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    preserve-scroll>
+                <div v-html="posts.links[posts.links.length - 1].label"></div>
+                </Link>
+            </div>
+            <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-center">
+                <div>
+                    <span class="relative z-0 inline-flex shadow-sm rounded-md">
+                        <template v-for="(link, key) in posts.links" :key="key">
+                            <Link :href="link.url || '#'"
+                                class="relative inline-flex items-center px-4 py-2 border text-sm font-medium" :class="{
+                                    'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-indigo-900 dark:border-indigo-700 dark:text-indigo-300': link.active,
+                                    'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700': !link.active && link.url,
+                                    'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-500': !link.url
+                                }" :disabled="!link.url" preserve-scroll>
+                            <div v-html="link.label"></div>
+                            </Link>
+                        </template>
+                    </span>
+                </div>
+            </div>
+        </nav>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+
+const props = defineProps<{
+    posts: {
+        data: Array<{
+            id: number;
+            title: string;
+            slug: string;
+            content: string; // Full content, we'll need to truncate for preview
+            updated_at: string;
+            user: {
+                name: string;
+            };
+            // Add other fields from your Post model as needed
+        }>;
+        links: Array<{
+            url: string | null;
+            label: string;
+            active: boolean;
+        }>;
+        // other pagination properties like current_page, last_page, etc., if needed directly
+    };
+}>();
+</script>

--- a/resources/js/components/IndexPagination.vue
+++ b/resources/js/components/IndexPagination.vue
@@ -4,14 +4,14 @@
             <div class="flex-1 flex justify-between sm:hidden">
                 <Link v-if="posts.links[0].url" :href="posts.links[0].url || '#'"
                     class="relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    preserve-scroll
-                    v-html="posts.links[0].label">
+                    preserve-scroll>
+                <div v-html="posts.links[0].label"></div>
                 </Link>
                 <Link v-if="posts.links[posts.links.length - 1].url"
                     :href="posts.links[posts.links.length - 1].url || '#'"
                     class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    preserve-scroll
-                    v-html="posts.links[posts.links.length - 1].label">
+                    preserve-scroll>
+                <div v-html="posts.links[posts.links.length - 1].label"></div>
                 </Link>
             </div>
             <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-center">
@@ -23,7 +23,8 @@
                                     'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-indigo-900 dark:border-indigo-700 dark:text-indigo-300': link.active,
                                     'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700': !link.active && link.url,
                                     'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-500': !link.url
-                                }" :disabled="!link.url" preserve-scroll v-html="link.label">
+                                }" :disabled="!link.url" preserve-scroll>
+                            <div v-html="link.label"></div>
                             </Link>
                         </template>
                     </span>
@@ -43,6 +44,7 @@ const { posts } = defineProps<{
             label: string;
             active: boolean;
         }>;
+        // other pagination properties like current_page, last_page, etc., if needed directly
     };
 }>();
 </script>

--- a/resources/js/components/IndexPagination.vue
+++ b/resources/js/components/IndexPagination.vue
@@ -37,7 +37,7 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
 
-const props = defineProps<{
+const { posts } = defineProps<{
     posts: {
         data: Array<{
             id: number;

--- a/resources/js/pages/Posts/Index.vue
+++ b/resources/js/pages/Posts/Index.vue
@@ -2,6 +2,7 @@
 import { Head, Link } from '@inertiajs/vue3';
 import BlogLayout from '@/layouts/BlogLayout.vue';
 import { computed } from 'vue';
+import IndexPagination from '@/components/IndexPagination.vue';
 
 // Define props from controller
 const props = defineProps<{
@@ -129,43 +130,7 @@ function formatDate(dateString: string) {
     </div>
 
     <!-- Pagination -->
-    <div v-if="posts.data.length > 0 && posts.links.length > 3" class="mt-12">
-      <nav class="flex items-center justify-between">
-        <div class="flex-1 flex justify-between sm:hidden">
-            <Link
-                v-if="posts.links[0].url"
-                :href="posts.links[0].url || '#'"
-                class="relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                preserve-scroll
-            ><div v-html="posts.links[0].label"></div></Link>
-            <Link
-                v-if="posts.links[posts.links.length - 1].url"
-                :href="posts.links[posts.links.length - 1].url || '#'"
-                class="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-700 text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
-                preserve-scroll
-            ><div v-html="posts.links[posts.links.length - 1].label"></div></Link>
-        </div>
-        <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-center">
-          <div>
-            <span class="relative z-0 inline-flex shadow-sm rounded-md">
-              <template v-for="(link, key) in posts.links" :key="key">
-                <Link
-                  :href="link.url || '#'"
-                  class="relative inline-flex items-center px-4 py-2 border text-sm font-medium"
-                  :class="{
-                    'z-10 bg-indigo-50 border-indigo-500 text-indigo-600 dark:bg-indigo-900 dark:border-indigo-700 dark:text-indigo-300': link.active,
-                    'bg-white border-gray-300 text-gray-500 hover:bg-gray-50 dark:bg-gray-800 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-700': !link.active && link.url,
-                    'bg-gray-100 border-gray-300 text-gray-400 cursor-not-allowed dark:bg-gray-700 dark:border-gray-600 dark:text-gray-500': !link.url
-                  }"
-                  :disabled="!link.url"
-                  preserve-scroll
-                ><div v-html="link.label"></div></Link>
-              </template>
-            </span>
-          </div>
-        </div>
-      </nav>
-    </div>
+    <IndexPagination :posts="posts" />
   </BlogLayout>
 </template>
 


### PR DESCRIPTION
# 概要
本次 PR 的核心目標是將 `文章一覽` 頁面中的分頁功能，提取為一個獨立的 Vue 元件。這項變更將提升程式碼的模組化程度、可重用性及可維護性，使分頁邏輯與頁面內容解耦，為未來在其他列表頁面複用分頁功能奠定基礎。

# 詳細變更內容
-  `Index.vue` 的 `Pagination` 元件化
   -  將 `Index` 頁面中所有與 `Pagination` 相關的 HTML 結構與邏輯，全部封裝到 `IndexPagination` 元件中。
   - 原先在 `Index` 頁面中處理分頁的程式碼已被移除，並替換為簡單地引用和使用新建立的 `IndexPagination` 元件。
   - 這使得 `Index` 頁面的職責更為專一，只負責數據的獲取和向子元件的傳遞，而分頁的展示和互動邏輯則完全由 `IndexPagination` 元件負責。

# 如何測試
1.  請確保開發環境已安裝所有專案依賴 (`./vendor/bin/sail npm install`)。
2.  執行專案啟動命令：`./vendor/bin/sail npm run dev`。
3.  開啟瀏覽器訪問 [localhost](http://localhost)。
4.  驗證分頁功能：
    - 檢查頁面底部或指定位置是否正確顯示分頁控制項。
    - 點擊不同的頁碼，確認頁面內容是否正確切換，且 URL 中的頁碼參數是否更新。
    - 確認「Previous」、「Next」按鈕功能是否正常，並在到達首頁或末頁時狀態是否正確。
    - 視覺上，分頁的外觀應與元件化前保持一致。

# 潛在風險與影響
無。本次變更主要為前端重構，不涉及核心功能邏輯的修改，因此預期對現有系統沒有顯著風險或負面影響。所有修改均應保持現有分頁功能的行為與外觀不變。

- Task 連結：[[HPB-77] [FE] 將文章一覽 Pagination 元件化](https://www.notion.so/jyu1999/FE-Pagination-21ecba948f118089a460dd0c3c217470?source=copy_link)